### PR TITLE
add .net library support, reverse extend order on options

### DIFF
--- a/example.pot
+++ b/example.pot
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+
+msgid "This is a test"
+msgstr "This is a test"
+
+msgid "I am groot!"
+msgstr "I am groot!"

--- a/index.js
+++ b/index.js
@@ -10,9 +10,10 @@ var pseudoTranslator = require('./lib/pseudo');
 var pluginName = require('./package.json').name;
 
 module.exports = function (options) {
-  options = _.extend({}, options, {
-    language: 'qps-ploc'
-  });
+  options = _.extend({
+    language: 'qps-ploc',
+    pathMode: 'ext'
+  }, options);
 
   return through.obj(function (file, enc, cb) {
     if (file.isNull()) {
@@ -24,15 +25,15 @@ module.exports = function (options) {
       this.emit('error', new gutil.PluginError(pluginName, 'Streaming not supported'));
       return cb();
     }
-    
+
     // Parse PO/POT file
     var parsed = gettext.po.parse(file.contents);
     parsed.headers['language'] = options.language;
-    
+
     // Translate
     var translations = parsed.translations;
     var pseudo = pseudoTranslator(options.charMap, options.excludes);
-    
+
     Object.keys(translations).forEach(function (catalog) {
       Object.keys(translations[catalog]).forEach(function (key) {
         if (key.length === 0) return;
@@ -46,15 +47,23 @@ module.exports = function (options) {
     });
 
     file.contents = gettext.po.compile(parsed);
-    
+
     // Rename abc.po or abc.pot to abc.[language].po
     var filePath = file.path;
     var dirname = path.dirname(filePath);
     var extension = path.extname(filePath);
     var basename = path.basename(filePath, extension);
-    file.path = path.join(dirname, basename + '.' + options.language + '.po');
-    
+
+    // the .NET i18n library expects folder-oriented structure
+    // e.g. fr/messages.po instead of messages.fr.po
+
+    switch (options.pathMode) {
+        case 'dir': file.path = path.join(dirname, options.language, basename + '.po'); break;
+        case 'ext': file.path = path.join(dirname, basename + '.' + options.language + '.po'); break;
+        default: throw new Error('invalid options.pathMode');
+    }
+
     this.push(file);
     cb();
   });
-}; 
+};

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "lodash": "^2.4.1",
     "through2": "~0.4.1"
   },
-  "devDependencies": { }
+  "devDependencies": {
+    "assert": "^1.3.0",
+    "gulp-util": "^2.2.20"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-pseudo-i18n",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Gulp plugin to generate pseudo translation from GNU gettext PO/POT files",
   "keywords": [
     "gulpplugin",

--- a/tests.js
+++ b/tests.js
@@ -1,0 +1,40 @@
+'use strict';
+var fs = require('fs');
+var assert = require('assert');
+var gutil = require('gulp-util');
+var gettext = require('gettext-parser');
+var i18n = require('./index');
+
+it('should create qps-ploc/example.po', function(cb) {
+
+    var stream = i18n({
+        pathMode: 'dir'
+    });
+
+    stream.write(new gutil.File({
+        path: __dirname + '/example.pot',
+        contents: fs.readFileSync(__dirname + '/example.pot'),
+    }));
+
+    stream.on('data', function (file) {
+        var path = file.path.replace(/\\/g,'/');
+        assert(/qps-ploc\/example\.po/gi.test(path))
+        cb();
+    });
+});
+
+it('should create example.qps-ploc.po', function(cb) {
+
+    var stream = i18n();
+
+    stream.write(new gutil.File({
+        path: __dirname + '/example.pot',
+        contents: fs.readFileSync(__dirname + '/example.pot'),
+    }));
+
+    stream.on('data', function (file) {
+        var path = file.path.replace(/\\/g,'/');
+        assert(/example\.qps-ploc\.po/gi.test(path))
+        cb();
+    });
+});


### PR DESCRIPTION
I added support for use with .NET projects utilizing the .net i18n library  at https://github.com/turquoiseowl/i18n. This library expects .po files in a folder based structure (e.g. fr/example.po instead of example.fr.po). To accomodate this, I added an option to use a 'dir' path mode vs the default 'ext' path mode for output files.

Also, your use of _.extend was incorrect. The subsequent objects override the former, so your defaults should be on the first empty object, followed by the inbound options argument.

Lastly, I added a mocha test for the two scenarios in the new tests.js file.
